### PR TITLE
Render monospaced table in HTML when not curl request

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ function errorHandler(error, res) {
 app.use(morgan(':remote-addr :remote-user :method :url :status :res[content-length] - :response-time ms'));
 
 app.get('/', (req, res) => {
+  const isCurl = req.headers['user-agent'].match(/\bcurl\b/gmi) !== null
   const format = req.query.format ? req.query.format : '';
 
   if (format.toLowerCase() === 'json') {
@@ -27,7 +28,7 @@ app.get('/', (req, res) => {
     }).catch(error => errorHandler(error, res));
   }
 
-  return getCompleteTable().then(result => {
+  return getCompleteTable({isCurl}).then(result => {
     res.setHeader('Cache-Control', 's-maxage=900');
     return res.send(result);
   }).catch(error => errorHandler(error, res));

--- a/app.js
+++ b/app.js
@@ -16,39 +16,40 @@ function errorHandler(error, res) {
 }
 
 app.use(morgan(':remote-addr :remote-user :method :url :status :res[content-length] - :response-time ms'));
+app.use((req, res, next) => {
+  res.setHeader('Cache-Control', 'no-cache');
+  next();
+});
 
 app.get('/', (req, res) => {
-  const isCurl = req.headers['user-agent'].match(/\bcurl\b/gmi) !== null
+  const isCurl = req.headers['user-agent'].match(/\bcurl\b/gmi) !== null;
   const format = req.query.format ? req.query.format : '';
 
   if (format.toLowerCase() === 'json') {
     return getJSONData().then(result => {
-      res.setHeader('Cache-Control', 's-maxage=900');
       return res.json(result);
     }).catch(error => errorHandler(error, res));
   }
 
-  return getCompleteTable({isCurl}).then(result => {
-    res.setHeader('Cache-Control', 's-maxage=900');
+  return getCompleteTable({ isCurl }).then(result => {
     return res.send(result);
   }).catch(error => errorHandler(error, res));
 });
 
 app.get('/:country', (req, res) => {
   const { country } = req.params;
+  const isCurl = req.headers['user-agent'].match(/\bcurl\b/gmi) !== null;
   const format = req.query.format ? req.query.format : '';
 
   if (!country || 'ALL' === country.toUpperCase()) {
     if (format.toLowerCase() === 'json') {
       return getJSONData().then(result => {
-        res.setHeader('Cache-Control', 's-maxage=900');
         return res.json(result);
       }).catch(error => errorHandler(error, res));
     }
 
 
-    return getCompleteTable().then(result => {
-      res.setHeader('Cache-Control', 's-maxage=900');
+    return getCompleteTable({ isCurl }).then(result => {
       return res.send(result);
     }).catch(error => errorHandler(error, res));
   }
@@ -70,13 +71,11 @@ app.get('/:country', (req, res) => {
 
   if (format.toLowerCase() === 'json') {
     return getJSONDataForCountry(iso2).then(result => {
-      res.setHeader('Cache-Control', 's-maxage=900');
       return res.json(result);
     }).catch(error => errorHandler(error, res));
   }
 
-  return getCountryTable(iso2).then(result => {
-    res.setHeader('Cache-Control', 's-maxage=900');
+  return getCountryTable({ countryCode: iso2, isCurl }).then(result => {
     return res.send(result);
   }).catch(error => errorHandler(error, res));
 });

--- a/bin/index.js
+++ b/bin/index.js
@@ -50,7 +50,7 @@ const { argv } = yargs
 const { emojis, country } = argv;
 (
   country === 'ALL'
-    ? getCompleteTable(emojis)
+    ? getCompleteTable({emojis})
     : getCountryTable(country, emojis)
 )
   .then(console.log)

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-const yargonaut = require('yargonaut')
-  .style('green');
+const yargonaut = require('yargonaut').style('green');
 const yargs = require('yargs');
 const chalk = require('chalk');
 const { getCompleteTable } = require('../lib/corona');
@@ -8,7 +7,7 @@ const { getCountryTable } = require('../lib/byCountry');
 const { lookupCountry } = require('../lib/helpers');
 
 const { argv } = yargs
-  .command('$0 [country]','Tool to COVID-19 statistics for the world or the given country', yargs =>
+  .command('$0 [country]','Tool to track COVID-19 statistics for the world or the given country', yargs =>
     yargs.positional('country', {
       coerce(arg) {
         if ('ALL' === arg.toUpperCase()) {
@@ -51,7 +50,7 @@ const { emojis, country } = argv;
 (
   country === 'ALL'
     ? getCompleteTable({emojis})
-    : getCountryTable(country, emojis)
+    : getCountryTable({ countryCode: country, emojis })
 )
   .then(console.log)
   .catch(console.error);

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,4 +1,4 @@
-const NodeCache = require( "node-cache" );
+const NodeCache = require('node-cache');
 const axios = require('axios');
 const myCache = new NodeCache( { stdTTL: 100, checkperiod: 600 } );
 const CORONA_ALL_KEY = 'coronaAll';

--- a/lib/byCountry.js
+++ b/lib/byCountry.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const chalk = require('chalk');
 const helpers = require('./helpers');
 const api = require('./api');
+const stripAnsi = require('strip-ansi');
 const {
   getCountry,
   getConfirmed,
@@ -79,7 +80,7 @@ exports.getJSONDataForCountry = async (countryCode) => {
   return countryData;
 }
 
-exports.getCountryTable = async (countryCode, emojis = false) => {
+exports.getCountryTable = async ({countryCode, emojis = false, isCurl = true}) => {
   const head = [
     '',
     'State',
@@ -147,5 +148,30 @@ exports.getCountryTable = async (countryCode, emojis = false) => {
     });
   }
   const lastUpdated = countryData[0].lastUpdated;
+  if (!isCurl) {
+    const template = `<!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" rel="stylesheet">
+      <title>Coronavirus Tracker</title>
+      <style>
+        body {
+          background: #0D0208;
+          color: #00FF41;
+        }
+        pre {
+          font-family: 'Roboto Mono', monospace;
+          white-space: pre;
+        }
+      </style>
+    </head>
+      <body>
+        <pre>${table.toString() + footer(lastUpdated)}</pre>
+      </body>
+    </html>`;
+    return stripAnsi(template);
+  }
   return table.toString() + footer(lastUpdated);
 }

--- a/lib/corona.js
+++ b/lib/corona.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const chalk = require('chalk');
 const helpers = require('./helpers');
 const api = require('./api');
+const stripAnsi = require('strip-ansi');
 const {
   getCountry,
   getConfirmed,
@@ -79,7 +80,7 @@ function extraStats(dataArr) {
   );
 }
 
-exports.getCompleteTable = async ({isCurl, emojis = false}) => {
+exports.getCompleteTable = async ({isCurl = true, emojis = false}) => {
   const head = [
     '',
     'Country',
@@ -148,6 +149,10 @@ exports.getCompleteTable = async ({isCurl, emojis = false}) => {
       <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" rel="stylesheet">
       <title>Coronavirus Tracker</title>
       <style>
+        body {
+          background:  #0D0208;
+          color: #00FF41;
+        }
         pre {
           font-family: 'Roboto Mono', monospace;
           white-space: pre;
@@ -158,7 +163,7 @@ exports.getCompleteTable = async ({isCurl, emojis = false}) => {
         <pre>${table.toString() + footer(lastUpdated)}</pre>
       </body>
     </html>`
-    return template;
+    return stripAnsi(template);
   }
   return table.toString() + footer(lastUpdated);
 }

--- a/lib/corona.js
+++ b/lib/corona.js
@@ -79,7 +79,7 @@ function extraStats(dataArr) {
   );
 }
 
-exports.getCompleteTable = async (emojis = false) => {
+exports.getCompleteTable = async ({isCurl, emojis = false}) => {
   const head = [
     '',
     'Country',
@@ -139,5 +139,26 @@ exports.getCompleteTable = async (emojis = false) => {
     table.push({ [rank++]: values })
   });
   const lastUpdated = countryData[0].lastUpdated;
+  if (!isCurl) {
+    const template = `<!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" rel="stylesheet">
+      <title>Coronavirus Tracker</title>
+      <style>
+        pre {
+          font-family: 'Roboto Mono', monospace;
+          white-space: pre;
+        }
+      </style>
+    </head>
+      <body>
+        <pre>${table.toString() + footer(lastUpdated)}</pre>
+      </body>
+    </html>`
+    return template;
+  }
   return table.toString() + footer(lastUpdated);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,9 @@
       }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "4.2.1",
@@ -1567,15 +1566,31 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.0"
       }
     },
     "strip-eof": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coronavirus-tracker-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "node-cache": "^5.1.0",
+    "strip-ansi": "^6.0.0",
     "yargonaut": "^1.1.4",
     "yargs": "15.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "corona": "./bin/index.js"
   },
   "scripts": {
-    "dev": "nodemon app.js",
+    "dev": "nodemon --inspect app.js",
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Addresses #21 
- If the user agent is not a curl request we respond with some formatted HTML
- Added `--inspect` flag to nodemon to allow using chrome dev tools debugging