### PR TITLE
Tweak HTML/CSS

### DIFF
--- a/lib/byCountry.js
+++ b/lib/byCountry.js
@@ -140,20 +140,19 @@ exports.getCountryTable = async ({
   }
   const lastUpdated = countryData[0].lastUpdated;
   if (!isCurl) {
-    const template = `<!DOCTYPE html>
+    const template = `<!doctype html>
     <html lang="en">
     <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" rel="stylesheet">
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>Coronavirus Tracker</title>
       <style>
         body {
-          background: #0D0208;
-          color: #00FF41;
+          background-color: #0d0208;
+          color: #00ff41;
         }
         pre {
-          font-family: 'Roboto Mono', monospace;
+          font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
           white-space: pre;
         }
       </style>

--- a/lib/corona.js
+++ b/lib/corona.js
@@ -161,20 +161,19 @@ exports.getCompleteTable = async ({
   })
   const lastUpdated = countryData[0].lastUpdated;
   if (!isCurl) {
-    const template = `<!DOCTYPE html>
+    const template = `<!doctype html>
     <html lang="en">
     <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" rel="stylesheet">
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>Coronavirus Tracker</title>
       <style>
         body {
-          background:  #0D0208;
-          color: #00FF41;
+          background-color: #0d0208;
+          color: #00ff41;
         }
         pre {
-          font-family: 'Roboto Mono', monospace;
+          font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
           white-space: pre;
         }
       </style>


### PR DESCRIPTION
* use the native font stack
* lowercase values

@sagarkarira this should be as fast as possible and smaller.

Comparison on Firefox on Windows

| Before | After |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/349621/77142795-e697e700-6a89-11ea-8300-9c27b21bdd78.png" alt="1-before" width="300"> | <img src="https://user-images.githubusercontent.com/349621/77142812-ee578b80-6a89-11ea-8760-b4255b342ef4.png" alt="2-after" width="300"> |
