### PR TITLE
Set `json escape` to true

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,8 @@ function errorHandler(error, res) {
   `);
 }
 
+app.set('json escape', true);
+
 app.use(morgan(':remote-addr :remote-user :method :url :status :res[content-length] - :response-time ms'));
 app.use((req, res, next) => {
   res.setHeader('Cache-Control', 'no-cache');


### PR DESCRIPTION
I think this shouldn't affect anything, but it's good practice IIRC.

From https://expressjs.com/en/api.html#app.settings.table:

>Enable escaping JSON responses from the `res.json`, `res.jsonp`, and `res.send` APIs. This will escape the characters `<`, `>`, and `&` as Unicode escape sequences in JSON. The purpose of this it to assist with [mitigating certain types of persistent XSS attacks](https://blog.mozilla.org/security/2017/07/18/web-service-audits-firefox-accounts/) when clients sniff responses for HTML.
