### PR TITLE
Fix json format parameter

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -249,13 +249,13 @@ https://corona-stats.online/uk?source=2&minimal=true     (with source and countr
 
 ---------------------------------------------------------------------------------
 
-# Get data as JSON - Add ?json=true
+# Get data as JSON - Add ?format=json
 
 ## Example:
-https://corona-stats.online?json=true
-https://corona-stats.online/Italy?json=true              (with country filter)
-https://corona-stats.online/?source=2&json=true          (with source)
-https://corona-stats.online/uk?source=2&json=true        (with source and country)
+https://corona-stats.online?format=json
+https://corona-stats.online/Italy?format=json            (with country filter)
+https://corona-stats.online/?source=2&format=json        (with source)
+https://corona-stats.online/uk?source=2&format=json      (with source and country)
 
 ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
Current doc:
```
$ curl -i https://corona-stats.online?json=true
HTTP/2 200 
content-type: text/html; charset=utf-8
...

(HTML follows)
```

with `format` parameter:
```
$ curl -i https://corona-stats.online?format=json
HTTP/2 200 
content-type: application/json; charset=utf-8
...

(JSON follows)
``` 
